### PR TITLE
Added `--log-file` switch.

### DIFF
--- a/VM/include/RigCVM/DevServer/Instance.hpp
+++ b/VM/include/RigCVM/DevServer/Instance.hpp
@@ -14,14 +14,14 @@ class DevelopmentServer
 public:
 	using LogStreamPtr = std::ostream*;
 
-	DevelopmentServer(LogStreamPtr loggingStream); // WebsocketFileLogger
+	DevelopmentServer(LogStreamPtr loggingStream);
 
 	void run();
 
 	void enqueueMessage(String msg_);
 
 private:
-	using ConnectionSet = std::set<ws::connection_hdl,std::owner_less<ws::connection_hdl>>;
+	using ConnectionSet = std::set<ws::connection_hdl, std::owner_less<ws::connection_hdl>>;
 
 	auto setupLoggingTo(std::ostream* loggingStream) -> void;
 

--- a/VM/include/RigCVM/DevServer/Instance.hpp
+++ b/VM/include/RigCVM/DevServer/Instance.hpp
@@ -12,7 +12,9 @@ using ServerBase = ws::server<ws::config::asio>;
 class DevelopmentServer
 {
 public:
-	DevelopmentServer();
+	using LogStreamPtr = std::ostream*;
+
+	DevelopmentServer(LogStreamPtr loggingStream); // WebsocketFileLogger
 
 	void run();
 
@@ -20,6 +22,8 @@ public:
 
 private:
 	using ConnectionSet = std::set<ws::connection_hdl,std::owner_less<ws::connection_hdl>>;
+
+	auto setupLoggingTo(std::ostream* loggingStream) -> void;
 
 	Queue<String>	_messageQueue;
 	ConnectionSet	_connections;

--- a/VM/include/RigCVM/VM.hpp
+++ b/VM/include/RigCVM/VM.hpp
@@ -37,6 +37,7 @@ struct Instance
 		std::chrono::milliseconds functionCallDelay{0};
 		std::chrono::milliseconds warmupDuration{0};
 		bool skipRootExceptionCatching = false;
+		std::string logFilePath;
 #endif
 	};
 

--- a/VM/src/DevServer/Instance.cpp
+++ b/VM/src/DevServer/Instance.cpp
@@ -9,11 +9,11 @@ DevelopmentServer* g_devServer = nullptr;
 
 static auto sendMtx = std::mutex();
 
-DevelopmentServer::DevelopmentServer()
+DevelopmentServer::DevelopmentServer(LogStreamPtr loggingStream)
 {
 	// Set logging settings
-	_endpoint.set_error_channels(ws::log::elevel::all);
-	_endpoint.set_access_channels(ws::log::alevel::all ^ ws::log::alevel::frame_payload);
+	if(loggingStream)
+		setupLoggingTo(loggingStream);
 
 	// Initialize Asio
 	_endpoint.init_asio();
@@ -103,6 +103,15 @@ void DevelopmentServer::enqueueMessage(String msg_)
 {
 	auto lock = std::scoped_lock(sendMtx);
 	_messageQueue.emplace( std::move(msg_) );
+}
+
+auto DevelopmentServer::setupLoggingTo(std::ostream* stream) -> void
+{
+	_endpoint.set_error_channels(ws::log::elevel::all);
+	_endpoint.set_access_channels(ws::log::alevel::all ^ ws::log::alevel::frame_payload);
+
+	_endpoint.get_alog().set_ostream(stream);
+	_endpoint.get_elog().set_ostream(stream);
 }
 
 }

--- a/VM/src/Main.cpp
+++ b/VM/src/Main.cpp
@@ -73,7 +73,7 @@ auto main(int argc, char* argv[]) -> int
 	};
 
 #if DEBUG
-	auto fileStream = std::make_unique<std::ofstream>(settings.logFilePath);
+	auto fileStream = std::make_unique<std::ofstream>(settings.logFilePath, std::ios_base::trunc);
 
 	auto server = [&settings, &fileStream] {
 		if(settings.logFilePath.empty()) {


### PR DESCRIPTION
Added `--log-file` switch which creates a file to which the websocket will log.
Without the switch no logging is initiated.

Example usage
```shell
rigcvm file.rigc --skipRootExceptionCatching --warmup=5000 --delay-fn=500 --log-file=log.log
```