### PR TITLE
Feat stack view

### DIFF
--- a/VM/include/RigCVM/DevServer/Utils.hpp
+++ b/VM/include/RigCVM/DevServer/Utils.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include RIGCVM_PCH
+
+namespace rigc::vm
+{
+
+auto formatStackFrameLabel(ParserNode const&) -> std::string;
+
+}

--- a/VM/include/RigCVM/Stack.hpp
+++ b/VM/include/RigCVM/Stack.hpp
@@ -43,7 +43,7 @@ R"(
 	"type": "stack",
 	"action": "pushFrame",
 	"data": {{
-		"initialSize": "{}",
+		"initialSize": "{}"
 	}}
 }}
 )", frame.initialStackSize)
@@ -63,7 +63,7 @@ R"(
 R"(
 {
 	"type": "stack",
-	"action": "popFrame",
+	"action": "popFrame"
 }
 )"
 	);

--- a/VM/include/RigCVM/Stack.hpp
+++ b/VM/include/RigCVM/Stack.hpp
@@ -36,20 +36,6 @@ struct Stack
 		frame.initialStackSize = this->size;
 		frames.push_back(frame);
 
-#ifdef DEBUG
-	sendDebugMessage(fmt::format(
-R"(
-{{
-	"type": "stack",
-	"action": "pushFrame",
-	"data": {{
-		"initialSize": "{}"
-	}}
-}}
-)", frame.initialStackSize)
-	);
-#endif
-
 		return frames.back();
 	}
 
@@ -57,17 +43,6 @@ R"(
 	{
 		size = frames.back().initialStackSize;
 		frames.pop_back();
-
-#ifdef DEBUG
-	sendDebugMessage(
-R"(
-{
-	"type": "stack",
-	"action": "popFrame"
-}
-)"
-	);
-#endif
 	}
 };
 

--- a/VM/include/RigCVM/Stack.hpp
+++ b/VM/include/RigCVM/Stack.hpp
@@ -3,6 +3,7 @@
 #include RIGCVM_PCH
 
 #include <RigCVM/StackFrame.hpp>
+#include <RigCVM/DevServer/Messaging.hpp>
 
 namespace rigc::vm
 {
@@ -34,6 +35,21 @@ struct Stack
 		StackFrame frame{this};
 		frame.initialStackSize = this->size;
 		frames.push_back(frame);
+
+#ifdef DEBUG
+	sendDebugMessage(fmt::format(
+R"(
+{{
+	"type": "stack",
+	"action": "pushFrame",
+	"data": {{
+		"initialSize": "{}",
+	}}
+}}
+)", frame.initialStackSize)
+	);
+#endif
+
 		return frames.back();
 	}
 
@@ -41,6 +57,17 @@ struct Stack
 	{
 		size = frames.back().initialStackSize;
 		frames.pop_back();
+
+#ifdef DEBUG
+	sendDebugMessage(
+R"(
+{
+	"type": "stack",
+	"action": "popFrame",
+}
+)"
+	);
+#endif
 	}
 };
 

--- a/VM/src/DevServer/Utils.cpp
+++ b/VM/src/DevServer/Utils.cpp
@@ -3,6 +3,7 @@
 #include <RigCVM/VM.hpp>
 #include <RigCVM/DevServer/Utils.hpp>
 
+#include <cctype>
 #include <numeric>
 #include <functional>
 
@@ -24,12 +25,15 @@ auto formatFunctionSignature(rigc::ParserNode const& node) {
 }
 
 auto stripBlockAndWhitespace(std::string& str) {
-	auto const prefixIt = rg::find_if(str, [](char c) { return std::isalpha(c); });
+	auto const firstAlphaCharIt = rg::find_if(str, ::isalpha);
 
 	auto const begin = rg::begin(str);
-	auto const end = begin + (prefixIt - begin);
+	auto const end = begin + (firstAlphaCharIt - begin);
 
-	str.erase(begin, end);
+	str.erase(
+        begin,
+		end
+    );
 }
 
 auto formatCodeBlock(rigc::ParserNode const& node) {

--- a/VM/src/DevServer/Utils.cpp
+++ b/VM/src/DevServer/Utils.cpp
@@ -1,0 +1,72 @@
+#include RIGCVM_PCH
+
+#include <RigCVM/VM.hpp>
+#include <RigCVM/DevServer/Utils.hpp>
+
+#include <numeric>
+#include <functional>
+
+namespace {
+
+auto formatFunctionSignature(rigc::ParserNode const& node) {
+	using namespace rigc;
+	using namespace rigc::vm;
+
+	auto const* const name = findElem<rigc::Name>(node);
+	auto const* const params = findElem<rigc::FunctionParams>(node);
+	auto const* const returnType = findElem<rigc::ExplicitReturnType>(node);
+
+	// name(arg1: type, arg2: type): return_type
+	return name->string()
+		+ (params ? params->string() : "()")
+		+ (returnType ? ": " : "")
+		+ (returnType ? returnType->string() : "");
+}
+
+auto stripWhitespace(std::string& str) {
+	auto const prefixIt = rg::find_if(str, [](char c) { return std::isalpha(c); });
+
+	auto const begin = rg::begin(str);
+	auto const end = begin + (prefixIt - begin);
+
+	str.erase(begin, end);
+}
+
+auto formatCodeBlock(rigc::ParserNode const& node) {
+	using namespace std::string_view_literals;
+
+	auto static constexpr maxLabelNameLen = 20;
+	auto static constexpr overflowIndicator = "..."sv;
+	auto static constexpr overflowIndicatorLen = overflowIndicator.length();
+	auto static constexpr maxAllowedLen = maxLabelNameLen - overflowIndicatorLen;
+
+	auto nodeString = node.string();
+
+	if (node.is_type<rigc::CodeBlock>()) {
+		stripWhitespace(nodeString);
+	}
+
+	if(nodeString.length() > maxLabelNameLen) {
+		return
+			nodeString.substr(0, maxAllowedLen)
+				+ std::string(overflowIndicator);
+	} else {
+		return nodeString;
+	}
+}
+
+}
+
+namespace rigc::vm {
+
+auto formatStackFrameLabel(ParserNode const& node) -> std::string {
+	auto const isFunctionDefinition = node.is_type<rigc::FunctionDefinition>();
+
+	if(isFunctionDefinition) {
+		return formatFunctionSignature(node);
+	} else {
+		return formatCodeBlock(node);
+	}
+}
+
+}

--- a/VM/src/DevServer/Utils.cpp
+++ b/VM/src/DevServer/Utils.cpp
@@ -23,7 +23,7 @@ auto formatFunctionSignature(rigc::ParserNode const& node) {
 		+ (returnType ? returnType->string() : "");
 }
 
-auto stripWhitespace(std::string& str) {
+auto stripBlockAndWhitespace(std::string& str) {
 	auto const prefixIt = rg::find_if(str, [](char c) { return std::isalpha(c); });
 
 	auto const begin = rg::begin(str);
@@ -43,7 +43,7 @@ auto formatCodeBlock(rigc::ParserNode const& node) {
 	auto nodeString = node.string();
 
 	if (node.is_type<rigc::CodeBlock>()) {
-		stripWhitespace(nodeString);
+		stripBlockAndWhitespace(nodeString);
 	}
 
 	if(nodeString.length() > maxLabelNameLen) {

--- a/VM/src/StackFrame.cpp
+++ b/VM/src/StackFrame.cpp
@@ -2,6 +2,7 @@
 
 #include <RigCVM/StackFrame.hpp>
 #include <RigCVM/VM.hpp>
+#include <RigCVM/DevServer/Utils.hpp>
 
 namespace rigc::vm
 {
@@ -11,7 +12,7 @@ StackFramePusher::StackFramePusher(Instance& vm_, ParserNode const& stmt_)
 	: vm(vm_)
 {
 #if DEBUG
-	vm.pushStackFrameOf(&stmt_, fmt::format("{} -> {}", stmt_.type, stmt_.string()));
+	vm.pushStackFrameOf(&stmt_, formatStackFrameLabel(stmt_));
 #else
 	vm.pushStackFrameOf(&stmt_);
 #endif

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -700,13 +700,6 @@ auto Instance::pushStackFrameOf(void const* addr_) -> Scope&
 {
 	Scope& scope = scopeOf(addr_);
 
-#if DEBUG
-	if (scope.name.empty())
-	{
-		scope.name = std::move(name);
-	}
-#endif
-
 	if (!scope.parent)
 		scope.parent = currentScope;
 
@@ -714,7 +707,25 @@ auto Instance::pushStackFrameOf(void const* addr_) -> Scope&
 	StackFrame& frame = stack.pushFrame();
 	frame.scope = &scope;
 
-	// fmt::print(">>> {}\n", (void*)&frame);
+#if DEBUG
+	if (scope.name.empty())
+	{
+		scope.name = std::move(name);
+	}
+
+	sendDebugMessage(fmt::format(
+R"(
+{{
+	"type": "stack",
+	"action": "pushFrame",
+	"data": {{
+		"initialSize": "{}"
+	}}
+}}
+)", frame.initialStackSize)
+	);
+
+#endif
 
 	return scope;
 }
@@ -738,6 +749,15 @@ auto Instance::popStackFrame() -> void
 			scopeName = scopeName.substr(0, 60) + "\n\t/* ... */";
 
 		// fmt::print(fg(color::gray), "Scope:\n{}\n", scopeName);
+
+		sendDebugMessage(
+R"(
+{
+	"type": "stack",
+	"action": "popFrame"
+}
+)"
+		);
 	}
 #endif
 

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -660,7 +660,7 @@ auto Instance::allocateOnStack(DeclType type_, void const* sourceBytes_, size_t 
 R"(
 {{
 	"type": "stack",
-	"action": "alllocate",
+	"action": "allocate",
 	"data": {{
 		"name": "{}",
 		"type": "{}",

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -653,6 +653,24 @@ auto Instance::allocateOnStack(DeclType type_, void const* sourceBytes_, size_t 
 	{
 		stack.frames.back().allocatedValues.push_back(val);
 	}
+#ifdef DEBUG
+	auto const typeWholeName = val.type->name();
+	auto const typeFirstLetter = typeWholeName.front();
+	sendDebugMessage(fmt::format(
+R"(
+{{
+	"type": "stack",
+	"action": "alllocate",
+	"data": {{
+		"name": "{}",
+		"type": "{}",
+		"size": {},
+		"address": {},
+	}}
+}}
+)", typeWholeName, typeFirstLetter, val.type->size(), stack.size) // the address will be an offset from the stack which is it's size
+	);
+#endif
 
 	return val;
 }

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -665,7 +665,7 @@ R"(
 		"name": "{}",
 		"type": "{}",
 		"size": {},
-		"address": {},
+		"address": {}
 	}}
 }}
 )", typeWholeName, typeFirstLetter, val.type->size(), stack.size) // the address will be an offset from the stack which is it's size

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -742,6 +742,17 @@ auto Instance::popStackFrame() -> void
 	assert(stack.frames.size() > 1 && "Tried to pop a universe scope-related stack frame.");
 
 	auto& frame = stack.frames.back();
+
+	// Destroy from the back to the front
+	auto& allocated = frame.allocatedValues;
+	for (auto it = allocated.rbegin(); it != allocated.rend(); ++it)
+	{
+		it->destroy(*this);
+	}
+
+	stack.popFrame();
+	currentScope = stack.frames.back().scope;
+
 #if DEBUG
 	// fmt::print("<<< {}, back {} bytes\n", (void*)&frame, stack.size - frame.initialStackSize);
 
@@ -766,15 +777,5 @@ R"(
 		);
 	}
 #endif
-
-	// Destroy from the back to the front
-	auto& allocated = frame.allocatedValues;
-	for (auto it = allocated.rbegin(); it != allocated.rend(); ++it)
-	{
-		it->destroy(*this);
-	}
-
-	stack.popFrame();
-	currentScope = stack.frames.back().scope;
 }
 }

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -708,6 +708,11 @@ auto Instance::pushStackFrameOf(void const* addr_) -> Scope&
 	frame.scope = &scope;
 
 #if DEBUG
+	if(addr_ != nullptr)
+	{
+		return scope;
+	}
+
 	if (scope.name.empty())
 	{
 		scope.name = std::move(name);

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -12,6 +12,7 @@
 #include <RigCVM/TypeSystem/ArrayType.hpp>
 #include <RigCVM/TypeSystem/FuncType.hpp>
 #include <RigCVM/DevServer/Messaging.hpp>
+#include <RigCVM/DevServer/Utils.hpp>
 
 #include <RigCVM/ErrorHandling/Exceptions.hpp>
 
@@ -289,7 +290,7 @@ R"msg(
 
 
 #if DEBUG
-		auto& fnScope			= this->pushStackFrameOf(func_.addr(), func_.runtimeImpl().node->string());
+		auto& fnScope			= this->pushStackFrameOf(func_.addr(), formatStackFrameLabel(*func_.runtimeImpl().node));
 #else
 		auto& fnScope			= this->pushStackFrameOf(func_.addr());
 #endif


### PR DESCRIPTION
Implemented the stack view from the interpreter side.
All of the stack actions are sent under the `stack` type.

There are 3 actions:
 - `pushFrame` with
```json
"data": {
 "initialSize": <number>
}
```

 - `popFrame` with no data
 - `allocate` with
```json
"data": {
 "name": "<string>",
 "type": "<string>",
 "size": <number>,
 "address": <number>
}
```