### PR TITLE
`Null` type and `null` keyword.

### DIFF
--- a/VM/include/RigCVM/Builtin/Functions.hpp
+++ b/VM/include/RigCVM/Builtin/Functions.hpp
@@ -36,16 +36,13 @@ auto printCharacters(Instance &vm_, Function::ArgSpan args_) -> OptValue;
 /// printCharacters("Hello, {}!\n", text);
 auto print(Instance &vm_, Function::ArgSpan args_) -> OptValue;
 
-/// @brief Returns the type of the given value, as a Array<Char, ?>.
-///
-/// @note This function will be completely reworked in the future because of
-/// varying return type (could not be properly compiled).
+/// @brief Prints the type of the given value.
 ///
 /// @example
 ///
 /// var text = "Hello, world!";
-/// print("{}\n", typeOf(text)); // prints "Array<Char, 13>"
-auto typeOf(Instance &vm_, Function::ArgSpan args_) -> OptValue;
+/// dumpTypeOf(text); // prints "Array<Char, 13>"
+auto dumpTypeOf(Instance &vm_, Function::ArgSpan args_) -> OptValue;
 
 /// @brief Reads an int from standard input.
 /// @returns Int32 - the read value.

--- a/VM/include/RigCVM/Type.hpp
+++ b/VM/include/RigCVM/Type.hpp
@@ -47,6 +47,7 @@ struct BuiltinTypes
 	};
 
 	Accessor Void;
+	Accessor Null;
 	Accessor Int16;
 	Accessor Int32;
 	Accessor Int64;

--- a/VM/include/RigCVM/TypeSystem/CoreType.hpp
+++ b/VM/include/RigCVM/TypeSystem/CoreType.hpp
@@ -6,12 +6,17 @@
 
 namespace rigc::vm
 {
+
+struct NullType {
+	void* value = nullptr;
+};
+
 class CoreType : public IType
 {
 public:
 	enum Kind : uint8_t
 	{
-		Void,
+		Void,		Null,
 		Int16,		Int32,		Int64,
 		Uint16,		Uint32,		Uint64,
 		Float32,	Float64,
@@ -24,7 +29,7 @@ private:
 	static constexpr auto Num = static_cast<size_t>(Kind::MAX);
 
 	static constexpr auto Sizes = std::to_array({
-			size_t(0),
+			size_t(0),			sizeof(NullType),
 			sizeof(int16_t),	sizeof(int32_t),	sizeof(int64_t),
 			sizeof(uint16_t),	sizeof(uint32_t),	sizeof(uint64_t),
 			sizeof(float),		sizeof(double),
@@ -33,7 +38,7 @@ private:
 		});
 
 	static constexpr auto Names = std::to_array<StringView>({
-			"Void",
+			"Void",		"Null",
 			"Int16",	"Int32",	"Int64",
 			"Uint16",	"Uint32",	"Uint64",
 			"Float32",	"Float64",
@@ -48,6 +53,7 @@ public:
 		#define ELSE_HANDLE_TYPE(CppName, EnumValue) else if constexpr (std::is_same_v<T, CppName>) return EnumValue;
 
 		HANDLE_TYPE		(void,		Void)
+		ELSE_HANDLE_TYPE(NullType,	Null)
 		ELSE_HANDLE_TYPE(int16_t,	Int16)
 		ELSE_HANDLE_TYPE(int32_t,	Int32)
 		ELSE_HANDLE_TYPE(int64_t,	Int64)

--- a/VM/include/RigCVM/Value.hpp
+++ b/VM/include/RigCVM/Value.hpp
@@ -115,10 +115,8 @@ struct FrameBasedValue : ValueBase
 
 using OptValue = std::optional<Value>;
 
-using ConversionFunc = OptValue(Instance &, Value const&);
+using ConversionFunc = Func<OptValue(Instance &, Value const&)>;
 
-template <typename T>
-auto addTypeConversion(Instance &vm_, Scope& universeScope_, DeclType const& from_, DeclType const& to_, ConversionFunc& func_) -> void;
-template <typename T>
-auto addTypeConversion(Instance &vm_, Scope& universeScope_, StringView from_, StringView to_, ConversionFunc& func_) -> void;
+auto addTypeConversion(Instance &vm_, Scope& universeScope_, DeclType const& from_, DeclType const& to_, ConversionFunc func_) -> void;
+auto addTypeConversion(Instance &vm_, Scope& universeScope_, StringView from_, StringView to_, ConversionFunc func_) -> void;
 }

--- a/VM/src/Builtin/Functions.cpp
+++ b/VM/src/Builtin/Functions.cpp
@@ -94,12 +94,12 @@ auto print(Instance &vm_, Function::ArgSpan args_) -> OptValue
 }
 
 ////////////////////////////////////////
-auto typeOf(Instance &vm_, Function::ArgSpan args_) -> OptValue
+auto dumpTypeOf(Instance &vm_, Function::ArgSpan args_) -> OptValue
 {
 	auto name = args_[0].safeRemoveRef().type->name();
-	auto t = vm_.arrayOf(*vm_.builtinTypes.Char.raw, name.size());
+	fmt::print("{}", name);
 
-	return vm_.allocateOnStack( t, name.data(), name.size() );
+	return std::nullopt;
 }
 
 ////////////////////////////////////////

--- a/VM/src/Executors/All.cpp
+++ b/VM/src/Executors/All.cpp
@@ -105,6 +105,13 @@ auto evaluateSymbol(Instance &vm_, rigc::ParserNode const& expr_) -> OptValue
 {
 	// Either "PossiblyTemplatedSymbol" or "PossiblyTemplatedSymbolNoDisamb"
 	auto& name	= *findElem<rigc::Name>(expr_, false);
+
+	if (name.string_view() == "null")
+	{
+		// TODO: protect against `null<TemplateArgs...>`
+		return vm_.allocateOnStack<void const*>(vm_.builtinTypes.Null.shared(), nullptr);
+	}
+
 	auto opt	= vm_.findVariableByName(name.string_view());
 
 	// if (!opt) {

--- a/VM/src/Executors/ExpressionExecutor.cpp
+++ b/VM/src/Executors/ExpressionExecutor.cpp
@@ -269,13 +269,13 @@ auto ExpressionExecutor::evalInfixOperator(StringView op_, Action& lhs_, Action&
 							.withHelp("Check the spelling of the rhs.")
 							.withLine(vm.lastEvaluatedLine);
 
-		auto const rhsType = vm.findType(rhs->string_view());
+		auto const rhsType = vm.evaluateType(*rhs);
 		if(!rhsType)
 			throw RigCError("Rhs of the conversion operator should be a type.")
 							.withHelp("Check the spelling of the rhs and if the type is in scope.")
 							.withLine(vm.lastEvaluatedLine);
 
-		return vm.tryConvert(lhs, rhsType->shared_from_this());
+		return vm.tryConvert(lhs, rhsType);
 	}
 	else
 	{

--- a/VM/src/Scope.cpp
+++ b/VM/src/Scope.cpp
@@ -22,6 +22,7 @@ auto setupUniverseScope(Instance &vm_, Scope& scope_) -> void
 		SetupCoreType<CppName>(vm_, scope_, *vm_.builtinTypes.RigCName.raw);
 
 	MAKE_BUILTIN_TYPE(void,		Void);
+	MAKE_BUILTIN_TYPE(NullType,	Null);
 	MAKE_BUILTIN_TYPE(bool,		Bool);
 	MAKE_BUILTIN_TYPE(char,		Char);
 	MAKE_BUILTIN_TYPE(char16_t,	Char16);
@@ -39,18 +40,17 @@ auto setupUniverseScope(Instance &vm_, Scope& scope_) -> void
 	scope_.addType(std::make_unique<MethodType>());
 
 	SETUP_BUILTIN_TYPE(bool,		Bool);
-	SETUP_BUILTIN_TYPE(void,		Void);
 	SETUP_BUILTIN_TYPE(char,		Char);
 	SETUP_BUILTIN_TYPE(char16_t,	Char16);
 	SETUP_BUILTIN_TYPE(char32_t,	Char32);
-	SETUP_BUILTIN_TYPE(int16_t,	Int16);
-	SETUP_BUILTIN_TYPE(int32_t,	Int32);
-	SETUP_BUILTIN_TYPE(int64_t,	Int64);
+	SETUP_BUILTIN_TYPE(int16_t,		Int16);
+	SETUP_BUILTIN_TYPE(int32_t,		Int32);
+	SETUP_BUILTIN_TYPE(int64_t,		Int64);
 	SETUP_BUILTIN_TYPE(uint16_t,	Uint16);
 	SETUP_BUILTIN_TYPE(uint32_t,	Uint32);
 	SETUP_BUILTIN_TYPE(uint64_t,	Uint64);
-	SETUP_BUILTIN_TYPE(float,	Float32);
-	SETUP_BUILTIN_TYPE(double,	Float64);
+	SETUP_BUILTIN_TYPE(float,		Float32);
+	SETUP_BUILTIN_TYPE(double,		Float64);
 
 
 	auto addrOfChar = constructTemplateType<AddrType>(scope_, vm_.builtinTypes.Char.shared());
@@ -96,11 +96,11 @@ auto setupUniverseScope(Instance &vm_, Scope& scope_) -> void
 	}
 	// "typeof" builtin function
 	{
-		auto func = Function{ &builtin::typeOf, {}, 0 };
+		auto func = Function{ &builtin::dumpTypeOf, {}, 0 };
 		func.variadic = true;
-		func.raw().name = "builtin::typeOf";
+		func.raw().name = "builtin::dumpTypeOf";
 
-		scope_.registerFunction(vm_, "typeOf", std::move(func));
+		scope_.registerFunction(vm_, "dumpTypeOf", std::move(func));
 	}
 	// "readInt" builtin function
 	{

--- a/VM/src/VM.cpp
+++ b/VM/src/VM.cpp
@@ -123,7 +123,7 @@ auto Instance::run(InstanceSettings const& settings_) -> int
 	this->pushStackFrameOf(nullptr);
 
 	#define ADD_CONVERSION(FromCppType, FromRigCName, ToRigCName) \
-		addTypeConversion<FromCppType>(*this, scope, #FromRigCName, #ToRigCName, builtinConvertOperator_##ToRigCName<FromCppType>)
+		addTypeConversion(*this, scope, #FromRigCName, #ToRigCName, builtinConvertOperator_##ToRigCName<FromCppType>)
 
 
 	// // Int16 -> floats


### PR DESCRIPTION
feat(vm): null keyword and `Null` type.
refactor(vm): change `typeOf` to `dumpTypeOf`

also fixed `as` operator to support templated symbols:
![image](https://user-images.githubusercontent.com/6839845/196041178-c2f5658e-e80c-4914-a5d0-a634d1d02d91.png)